### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,9 @@ maintenance = { status = "actively-developed"}
 [lib]
 
 [dependencies]
-reqwest = { version = "0", features = ["blocking", "json"] }
+reqwest = { version = "0.11", features = ["blocking", "json"] }
 clap = { version = "3", features = ["derive"] }
 serde_json = "1"
 tempfile = "3"
-fancy-regex = "0"
-rand = "0"
-
+fancy-regex = "0.10"
+rand = "0.8"


### PR DESCRIPTION
Mentioning "0" would mean cargo would pick the latest dependency which is versioned "0.*" which would include versions incompatible with the one that this crate was written with and may break your create.